### PR TITLE
Dev v1.2.0

### DIFF
--- a/hepexplorer.js
+++ b/hepexplorer.js
@@ -285,7 +285,11 @@
                 },
                 xMeasure: null, //set in syncSettings
                 yMeasure: null, //set in syncSettings
-                display: null //set in syncSettings
+                display: null, //set in syncSettings
+                defaults: {
+                    relative_baseline: 3.8,
+                    relative_uln: 3
+                }
             },
             imputation_methods: {
                 ALT: 'data-driven',
@@ -847,6 +851,23 @@
                 }
             });
         });
+
+        //check that all measure_values have associated cut measure_values
+        console.log(config.cuts);
+        Object.keys(config.measure_values).forEach(function(m) {
+            console.log(m);
+            // does a cut point for the custom value exist? if not create it.
+            if (!config.cuts.hasOwnProperty(m)) {
+                config.cuts[m] = {};
+            }
+
+            // does the cut have non-null baseline and ULN cuts associated, if not use the default values
+            config.cuts[m].relative_baseline =
+                config.cuts[m].relative_baseline || config.cuts.defaults.relative_baseline;
+            config.cuts[m].relative_uln =
+                config.cuts[m].relative_uln || config.cuts.defaults.relative_uln;
+        });
+        console.log(config.cuts);
     }
 
     function iterateOverData() {

--- a/hepexplorer.js
+++ b/hepexplorer.js
@@ -262,19 +262,12 @@
                 TB: 'Total Bilirubin',
                 ALP: 'Alkaline phosphatase (ALP)'
             },
-            x_options: ['ALT', 'AST', 'ALP'],
+            addMeasures: false,
+            x_options: 'all',
             y_options: ['TB'],
             point_size: 'Uniform',
-            point_size_options: ['ALT', 'AST', 'ALP', 'TB', 'rRatio'],
+            point_size_options: 'all',
             cuts: {
-                ALT: {
-                    relative_baseline: 3.8,
-                    relative_uln: 3
-                },
-                AST: {
-                    relative_baseline: 3.8,
-                    relative_uln: 3
-                },
                 TB: {
                     relative_baseline: 4.8,
                     relative_uln: 2
@@ -283,9 +276,6 @@
                     relative_baseline: 3.8,
                     relative_uln: 1
                 },
-                xMeasure: null, //set in syncSettings
-                yMeasure: null, //set in syncSettings
-                display: null, //set in syncSettings
                 defaults: {
                     relative_baseline: 3.8,
                     relative_uln: 3
@@ -388,18 +378,21 @@
     }
 
     //Replicate settings in multiple places in the settings object
-    function syncSettings(settings) {
-        settings.marks[0].per[0] = settings.id_col;
+    function syncSettings(settings$$1) {
+        var defaults = settings();
+        settings$$1.marks[0].per[0] = settings$$1.id_col;
 
         //set grouping config
-        if (typeof settings.group_cols == 'string') {
-            settings.group_cols = [{ value_col: settings.group_cols, label: settings.group_cols }];
+        if (typeof settings$$1.group_cols == 'string') {
+            settings$$1.group_cols = [
+                { value_col: settings$$1.group_cols, label: settings$$1.group_cols }
+            ];
         }
 
-        if (!(settings.group_cols instanceof Array && settings.group_cols.length)) {
-            settings.group_cols = [{ value_col: 'NONE', label: 'None' }];
+        if (!(settings$$1.group_cols instanceof Array && settings$$1.group_cols.length)) {
+            settings$$1.group_cols = [{ value_col: 'NONE', label: 'None' }];
         } else {
-            settings.group_cols = settings.group_cols.map(function(group) {
+            settings$$1.group_cols = settings$$1.group_cols.map(function(group) {
                 return {
                     value_col: group.value_col || group,
                     label: group.label || group.value_col || group
@@ -407,33 +400,34 @@
             });
 
             var hasNone =
-                settings.group_cols
+                settings$$1.group_cols
                     .map(function(m) {
                         return m.value_col;
                     })
                     .indexOf('NONE') > -1;
             if (!hasNone) {
-                settings.group_cols.unshift({ value_col: 'NONE', label: 'None' });
+                settings$$1.group_cols.unshift({ value_col: 'NONE', label: 'None' });
             }
         }
 
-        if (settings.group_cols.length > 1) {
-            settings.color_by = settings.group_cols[1].value_col
-                ? settings.group_cols[1].value_col
-                : settings.group_cols[1];
+        if (settings$$1.group_cols.length > 1) {
+            settings$$1.color_by = settings$$1.group_cols[1].value_col
+                ? settings$$1.group_cols[1].value_col
+                : settings$$1.group_cols[1];
         } else {
-            settings.color_by = 'NONE';
+            settings$$1.color_by = 'NONE';
         }
 
         //make sure filters is an Array
-        if (!(settings.filters instanceof Array)) {
-            settings.filters = typeof settings.filters == 'string' ? [settings.filters] : [];
+        if (!(settings$$1.filters instanceof Array)) {
+            settings$$1.filters =
+                typeof settings$$1.filters == 'string' ? [settings$$1.filters] : [];
         }
 
         //Define default details.
-        var defaultDetails = [{ value_col: settings.id_col, label: 'Subject Identifier' }];
-        if (settings.filters) {
-            settings.filters.forEach(function(filter) {
+        var defaultDetails = [{ value_col: settings$$1.id_col, label: 'Subject Identifier' }];
+        if (settings$$1.filters) {
+            settings$$1.filters.forEach(function(filter) {
                 var obj = {
                     value_col: filter.value_col ? filter.value_col : filter,
                     label: filter.label
@@ -453,8 +447,8 @@
             });
         }
 
-        if (settings.group_cols) {
-            settings.group_cols
+        if (settings$$1.group_cols) {
+            settings$$1.group_cols
                 .filter(function(f) {
                     return f.value_col != 'NONE';
                 })
@@ -478,17 +472,18 @@
         }
 
         //parse details to array if needed
-        if (!(settings.details instanceof Array)) {
-            settings.details = typeof settings.details == 'string' ? [settings.details] : [];
+        if (!(settings$$1.details instanceof Array)) {
+            settings$$1.details =
+                typeof settings$$1.details == 'string' ? [settings$$1.details] : [];
         }
 
         //If [settings.details] is not specified:
-        if (!settings.details) settings.details = defaultDetails;
+        if (!settings$$1.details) settings$$1.details = defaultDetails;
         else {
             //If [settings.details] is specified:
             //Allow user to specify an array of columns or an array of objects with a column property
             //and optionally a column label.
-            settings.details.forEach(function(detail) {
+            settings$$1.details.forEach(function(detail) {
                 if (
                     defaultDetails
                         .map(function(d) {
@@ -505,45 +500,69 @@
                             : detail
                     });
             });
-            settings.details = defaultDetails;
+            settings$$1.details = defaultDetails;
         }
 
         // If settings.analysisFlag is null
-        if (!settings.analysisFlag) settings.analysisFlag = { value_col: null, values: [] };
-        if (!settings.analysisFlag.value_col) settings.analysisFlag.value_col = null;
-        if (!(settings.analysisFlag.values instanceof Array)) {
-            settings.analysisFlag.values =
-                typeof settings.analysisFlag.values == 'string'
-                    ? [settings.analysisFlag.values]
+        if (!settings$$1.analysisFlag) settings$$1.analysisFlag = { value_col: null, values: [] };
+        if (!settings$$1.analysisFlag.value_col) settings$$1.analysisFlag.value_col = null;
+        if (!(settings$$1.analysisFlag.values instanceof Array)) {
+            settings$$1.analysisFlag.values =
+                typeof settings$$1.analysisFlag.values == 'string'
+                    ? [settings$$1.analysisFlag.values]
                     : [];
         }
         //if it is null, set settings.baseline.value_col to settings.studyday_col.
-        if (!settings.baseline) settings.baseline = { value_col: null, values: [] };
-        if (!settings.baseline.value_col) settings.baseline.value_col = settings.studyday_col;
-        if (!(settings.baseline.values instanceof Array)) {
-            settings.baseline.values =
-                typeof settings.baseline.values == 'string' ? [settings.baseline.values] : [];
+        if (!settings$$1.baseline) settings$$1.baseline = { value_col: null, values: [] };
+        if (!settings$$1.baseline.value_col)
+            settings$$1.baseline.value_col = settings$$1.studyday_col;
+        if (!(settings$$1.baseline.values instanceof Array)) {
+            settings$$1.baseline.values =
+                typeof settings$$1.baseline.values == 'string' ? [settings$$1.baseline.values] : [];
         }
+
+        //check for 'all' in x_, y_ and point_size_options
+        var allMeasures = Object.keys(settings$$1.measure_values);
+        if (settings$$1.x_options == 'all') settings$$1.x_options = allMeasures;
+        if (settings$$1.y_options == 'all') settings$$1.y_options = allMeasures;
+        if (settings$$1.point_size_options == 'all') settings$$1.point_size_options = allMeasures;
 
         //parse x_ and y_options to array if needed
-        if (!(settings.x_options instanceof Array)) {
-            settings.x_options = typeof settings.x_options == 'string' ? [settings.x_options] : [];
+        if (!(settings$$1.x_options instanceof Array)) {
+            settings$$1.x_options =
+                typeof settings$$1.x_options == 'string' ? [settings$$1.x_options] : [];
         }
 
-        if (!(settings.y_options instanceof Array)) {
-            settings.y_options = typeof settings.y_options == 'string' ? [settings.y_options] : [];
+        if (!(settings$$1.y_options instanceof Array)) {
+            settings$$1.y_options =
+                typeof settings$$1.y_options == 'string' ? [settings$$1.y_options] : [];
         }
-
-        // track initial Cutpoint (lets us detect when cutpoint should change)
-        settings.cuts.x = settings.x.column;
-        settings.cuts.y = settings.y.column;
-        settings.cuts.display = settings.display;
 
         //Attach measure columns to axis settings.
-        settings.x.column = settings.x_options[0];
-        settings.y.column = settings.y_options[0];
+        settings$$1.x.column = settings$$1.x_options[0];
+        settings$$1.y.column = settings$$1.y_options[0];
 
-        return settings;
+        // track initial Cutpoint  (lets us detect when cutpoint should change)
+        settings$$1.cuts.x = settings$$1.x.column;
+        settings$$1.cuts.y = settings$$1.y.column;
+        settings$$1.cuts.display = settings$$1.display;
+
+        // Confirm detaults are set
+        settings$$1.cuts.defaults = settings$$1.cuts.defaults || defaults.cuts.defaults;
+        settings$$1.cuts.defaults.relative_uln =
+            settings$$1.cuts.defaults.relative_uln || defaults.cuts.defaults.relative_uln;
+        settings$$1.cuts.defaults.relative_baseline =
+            settings$$1.cuts.defaults.relative_baseline || defaults.cuts.defaults.relative_baseline;
+
+        // keep default cuts if user hasn't provided an alternative
+        var cutMeasures = Object.keys(settings$$1.cuts);
+        Object.keys(defaults.cuts).forEach(function(m) {
+            if (cutMeasures.indexOf(m) == -1) {
+                settings$$1.cuts[m] = defaults.cuts[m];
+            }
+        });
+
+        return settings$$1;
     }
 
     function controlInputs() {
@@ -627,7 +646,7 @@
                 description: 'Parameter to set point radius',
                 options: ['point_size'],
                 start: null, // set in syncControlInputs()
-                values: ['Uniform'],
+                values: ['Uniform', 'rRatio'],
                 require: true
             },
             {
@@ -852,11 +871,9 @@
             });
         });
 
-        //check that all measure_values have associated cut measure_values
-        console.log(config.cuts);
+        //check that all measure_values have associated cuts
         Object.keys(config.measure_values).forEach(function(m) {
-            console.log(m);
-            // does a cut point for the custom value exist? if not create it.
+            // does a cut point for the measure exist? If not, create a placeholder.
             if (!config.cuts.hasOwnProperty(m)) {
                 config.cuts[m] = {};
             }
@@ -867,7 +884,6 @@
             config.cuts[m].relative_uln =
                 config.cuts[m].relative_uln || config.cuts.defaults.relative_uln;
         });
-        console.log(config.cuts);
     }
 
     function iterateOverData() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hep-explorer",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hep-explorer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hep-explorer",
   "description": "Interactive Graphic for Exploring Hepatic Data in Clinical Trials",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Rho, Inc.",
   "license": "MIT",
   "homepage": "https://github.com/SafetyGraphics/hep-explorer#readme",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hep-explorer",
   "description": "Interactive Graphic for Exploring Hepatic Data in Clinical Trials",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": "Rho, Inc.",
   "license": "MIT",
   "homepage": "https://github.com/SafetyGraphics/hep-explorer#readme",

--- a/src/callbacks/onInit/checkMeasureDetails.js
+++ b/src/callbacks/onInit/checkMeasureDetails.js
@@ -37,4 +37,18 @@ export default function checkMeasureDetails() {
             }
         });
     });
+
+    //check that all measure_values have associated cut measure_values
+    Object.keys(config.measure_values).forEach(function(m) {
+        // does a cut point for the custom value exist? if not create it.
+        if (!config.cuts.hasOwnProperty(m)) {
+            config.cuts[m] = {};
+        }
+
+        // does the cut have non-null baseline and ULN cuts associated, if not use the default values
+        config.cuts[m].relative_baseline =
+            config.cuts[m].relative_baseline || config.cuts.defaults.relative_baseline;
+        config.cuts[m].relative_uln =
+            config.cuts[m].relative_uln || config.cuts.defaults.relative_uln;
+    });
 }

--- a/src/callbacks/onInit/checkMeasureDetails.js
+++ b/src/callbacks/onInit/checkMeasureDetails.js
@@ -47,21 +47,26 @@ export default function checkMeasureDetails() {
             }
         });
 
-        // add options for controls requesting 'all' measures
-        if (config[setting + '_all']) {
-            const point_size_options = d3.merge([['Uniform', 'rRatio'], valid_options]);
-            config[setting] = setting == 'point_size_options' ? point_size_options : valid_options;
-            const controlLabel =
-                setting == 'x_options'
-                    ? 'X-axis Measure'
-                    : setting == 'y_options'
-                    ? 'Y-axis Measure'
-                    : 'Point Size';
-            var input = chart.controls.config.inputs.find(ci => ci.label == controlLabel);
-            input.values = config[setting];
+        // update the control input settings
+        const controlLabel =
+            setting == 'x_options'
+                ? 'X-axis Measure'
+                : setting == 'y_options'
+                ? 'Y-axis Measure'
+                : 'Point Size';
+        var input = chart.controls.config.inputs.find(ci => ci.label == controlLabel);
+
+        if (input) {
+            //only update this if the input settings exist - axis inputs with only one value are deleted
+            // add options for controls requesting 'all' measures
+            if (config[setting + '_all']) {
+                const point_size_options = d3.merge([['Uniform', 'rRatio'], valid_options]);
+                config[setting] =
+                    setting == 'point_size_options' ? point_size_options : valid_options;
+                input.values = config[setting];
+            }
         }
     });
-
     //check that all measure_values have associated cuts
     Object.keys(config.measure_values).forEach(function(m) {
         // does a cut point for the measure exist? If not, create a placeholder.

--- a/src/callbacks/onInit/checkMeasureDetails.js
+++ b/src/callbacks/onInit/checkMeasureDetails.js
@@ -21,21 +21,45 @@ export default function checkMeasureDetails() {
             }: ${missingMeasures.join(', ')}.`
         );
 
+    //automatically add Measures if requested
+    if (config.add_measures) {
+        measures.forEach(function(m, i) {
+            if (specifiedMeasures.indexOf(m) == -1) {
+                config.measure_values['m' + i] = m;
+            }
+        });
+    }
+
     //check that x_options, y_options and size_options all have value keys/values in measure_values
-    const valid_options = d3.merge([Object.keys(config.measure_values), ['rRatio']]);
-    const all_options = ['x_options', 'y_options', 'point_size_options'];
-    all_options.forEach(function(options) {
-        config[options].forEach(function(option) {
+    const valid_options = Object.keys(config.measure_values);
+    const all_settings = ['x_options', 'y_options', 'point_size_options'];
+    all_settings.forEach(function(setting) {
+        // remove invalid options
+        config[setting].forEach(function(option) {
             if (valid_options.indexOf(option) == -1) {
                 delete config[options][option];
                 console.warn(
                     option +
                         " wasn't found in the measure_values index and has been removed from config." +
-                        options +
+                        setting +
                         '. This may cause problems with the chart.'
                 );
             }
         });
+
+        // add options for controls requesting 'all' measures
+        if (config[setting + '_all']) {
+            const point_size_options = d3.merge([['Uniform', 'rRatio'], valid_options]);
+            config[setting] = setting == 'point_size_options' ? point_size_options : valid_options;
+            const controlLabel =
+                setting == 'x_options'
+                    ? 'X-axis Measure'
+                    : setting == 'y_options'
+                    ? 'Y-axis Measure'
+                    : 'Point Size';
+            var input = chart.controls.config.inputs.find(ci => ci.label == controlLabel);
+            input.values = config[setting];
+        }
     });
 
     //check that all measure_values have associated cuts

--- a/src/callbacks/onInit/checkMeasureDetails.js
+++ b/src/callbacks/onInit/checkMeasureDetails.js
@@ -38,9 +38,9 @@ export default function checkMeasureDetails() {
         });
     });
 
-    //check that all measure_values have associated cut measure_values
+    //check that all measure_values have associated cuts
     Object.keys(config.measure_values).forEach(function(m) {
-        // does a cut point for the custom value exist? if not create it.
+        // does a cut point for the measure exist? If not, create a placeholder.
         if (!config.cuts.hasOwnProperty(m)) {
             config.cuts[m] = {};
         }

--- a/src/callbacks/onLayout.js
+++ b/src/callbacks/onLayout.js
@@ -14,6 +14,7 @@ import { initControlLabels } from './onLayout/initControlLabels';
 import { addFootnote } from './onLayout/addFootnote';
 import { addDownloadButton } from './onLayout/addDownloadButton';
 import { initEmptyChartWarning } from './onLayout/initEmptyChartWarning';
+import { relabelMeasureControls } from './onLayout/relabelMeasureControls';
 
 import customizePlotStyleToggle from './onLayout/customizePlotStyleToggle';
 import initStudyDayControl from './onLayout/initStudyDayControl';
@@ -41,4 +42,5 @@ export default function onLayout() {
     initControlLabels.call(this);
     initEmptyChartWarning.call(this);
     initStudyDayControl.call(this);
+    relabelMeasureControls.call(this);
 }

--- a/src/callbacks/onLayout/relabelMeasureControls.js
+++ b/src/callbacks/onLayout/relabelMeasureControls.js
@@ -1,0 +1,15 @@
+export function relabelMeasureControls() {
+    var chart = this;
+    var config = this.config;
+    const all_settings = ['x_options', 'y_options', 'point_size_options'];
+    const controlLabels = ['X-axis Measure', 'Y-axis Measure', 'Point Size'];
+    const controlWraps = chart.controls.wrap
+        .selectAll('div')
+        .filter(controlInput => controlLabels.indexOf(controlInput.label) > -1);
+    const controls = controlWraps.select('select');
+    const options = controls.selectAll('option');
+    var allKeys = Object.keys(config.measure_values);
+    options
+        .text(d => (allKeys.indexOf(d) > -1 ? config.measure_values[d] : d))
+        .property('value', d => d);
+}

--- a/src/configuration/controlInputs.js
+++ b/src/configuration/controlInputs.js
@@ -79,7 +79,7 @@ export default function controlInputs() {
             description: 'Parameter to set point radius',
             options: ['point_size'],
             start: null, // set in syncControlInputs()
-            values: ['Uniform'],
+            values: ['Uniform', 'rRatio'],
             require: true
         },
         {

--- a/src/configuration/settings.js
+++ b/src/configuration/settings.js
@@ -60,7 +60,11 @@ export default function settings() {
             },
             xMeasure: null, //set in syncSettings
             yMeasure: null, //set in syncSettings
-            display: null //set in syncSettings
+            display: null, //set in syncSettings
+            defaults: {
+                relative_baseline: 3.8,
+                relative_uln: 3
+            }
         },
         imputation_methods: {
             ALT: 'data-driven',

--- a/src/configuration/settings.js
+++ b/src/configuration/settings.js
@@ -39,9 +39,11 @@ export default function settings() {
         },
         add_measures: false,
         x_options: 'all',
+        x_default: 'ALT',
         y_options: ['TB'],
-        point_size: 'Uniform',
+        y_default: 'TB',
         point_size_options: 'all',
+        point_size_default: 'Uniform',
         cuts: {
             TB: {
                 relative_baseline: 4.8,

--- a/src/configuration/settings.js
+++ b/src/configuration/settings.js
@@ -37,19 +37,12 @@ export default function settings() {
             TB: 'Total Bilirubin',
             ALP: 'Alkaline phosphatase (ALP)'
         },
-        x_options: ['ALT', 'AST', 'ALP'],
+        addMeasures: false,
+        x_options: 'all',
         y_options: ['TB'],
         point_size: 'Uniform',
-        point_size_options: ['ALT', 'AST', 'ALP', 'TB', 'rRatio'],
+        point_size_options: 'all',
         cuts: {
-            ALT: {
-                relative_baseline: 3.8,
-                relative_uln: 3
-            },
-            AST: {
-                relative_baseline: 3.8,
-                relative_uln: 3
-            },
             TB: {
                 relative_baseline: 4.8,
                 relative_uln: 2
@@ -58,9 +51,6 @@ export default function settings() {
                 relative_baseline: 3.8,
                 relative_uln: 1
             },
-            xMeasure: null, //set in syncSettings
-            yMeasure: null, //set in syncSettings
-            display: null, //set in syncSettings
             defaults: {
                 relative_baseline: 3.8,
                 relative_uln: 3

--- a/src/configuration/settings.js
+++ b/src/configuration/settings.js
@@ -37,7 +37,7 @@ export default function settings() {
             TB: 'Total Bilirubin',
             ALP: 'Alkaline phosphatase (ALP)'
         },
-        addMeasures: false,
+        add_measures: false,
         x_options: 'all',
         y_options: ['TB'],
         point_size: 'Uniform',

--- a/src/configuration/syncControlInputs.js
+++ b/src/configuration/syncControlInputs.js
@@ -33,7 +33,7 @@ export default function syncControlInputs(controlInputs, settings) {
             controlInput => controlInput.option === 'x.column'
         );
 
-        xAxisMeasureControl.description = settings.x_options.join(', ');
+        //xAxisMeasureControl.description = settings.x_options.join(', ');
         xAxisMeasureControl.start = settings.x_options[0];
         xAxisMeasureControl.values = settings.x_options;
     }
@@ -60,7 +60,7 @@ export default function syncControlInputs(controlInputs, settings) {
         const yAxisMeasureControl = controlInputs.find(
             controlInput => controlInput.option === 'y.column'
         );
-        yAxisMeasureControl.description = settings.y_options.join(', ');
+        //  yAxisMeasureControl.description = settings.y_options.join(', ');
         yAxisMeasureControl.start = settings.y_options[0];
         yAxisMeasureControl.values = settings.y_options;
     }

--- a/src/configuration/syncControlInputs.js
+++ b/src/configuration/syncControlInputs.js
@@ -34,7 +34,7 @@ export default function syncControlInputs(controlInputs, settings) {
         );
 
         //xAxisMeasureControl.description = settings.x_options.join(', ');
-        xAxisMeasureControl.start = settings.x_options[0];
+        xAxisMeasureControl.start = settings.x.column;
         xAxisMeasureControl.values = settings.x_options;
     }
 
@@ -61,7 +61,7 @@ export default function syncControlInputs(controlInputs, settings) {
             controlInput => controlInput.option === 'y.column'
         );
         //  yAxisMeasureControl.description = settings.y_options.join(', ');
-        yAxisMeasureControl.start = settings.y_options[0];
+        yAxisMeasureControl.start = settings.y.column;
         yAxisMeasureControl.values = settings.y_options;
     }
 
@@ -93,7 +93,7 @@ export default function syncControlInputs(controlInputs, settings) {
 
     const pointSizeControl = controlInputs.find(ci => ci.label === 'Point Size');
 
-    pointSizeControl.start = settings.point_size || 'Uniform';
+    pointSizeControl.start = settings.point_size;
 
     settings.point_size_options.forEach(function(d) {
         pointSizeControl.values.push(d);

--- a/src/configuration/syncSettings.js
+++ b/src/configuration/syncSettings.js
@@ -112,6 +112,12 @@ export default function syncSettings(settings) {
             typeof settings.baseline.values == 'string' ? [settings.baseline.values] : [];
     }
 
+    //merge in default measure_values if user hasn't specified changes
+    Object.keys(defaults.measure_values).forEach(function(val) {
+        if (!settings.measure_values.hasOwnProperty(val))
+            settings.measure_values[val] = defaults.measure_values[val];
+    });
+
     //check for 'all' in x_, y_ and point_size_options, but keep track if all options are used for later
     const allMeasures = Object.keys(settings.measure_values);
     settings.x_options_all = settings.x_options == 'all';
@@ -130,16 +136,28 @@ export default function syncSettings(settings) {
         settings.y_options = typeof settings.y_options == 'string' ? [settings.y_options] : [];
     }
 
-    //Attach measure columns to axis settings.
-    settings.x.column = settings.x_options[0];
-    settings.y.column = settings.y_options[0];
+    //set starting values for axis and point size settings.
+    settings.point_size =
+        settings.point_size_options.indexOf(settings.point_size_default) > -1
+            ? settings.point_size_default
+            : settings.point_size_default == 'rRatio'
+            ? 'rRatio'
+            : 'Uniform';
+    settings.x.column =
+        settings.x_options.indexOf(settings.x_default) > -1
+            ? settings.x_default
+            : settings.x_options[0];
+    settings.y.column =
+        settings.y_options.indexOf(settings.y_default) > -1
+            ? settings.y_default
+            : settings.y_options[0];
 
     // track initial Cutpoint  (lets us detect when cutpoint should change)
     settings.cuts.x = settings.x.column;
     settings.cuts.y = settings.y.column;
     settings.cuts.display = settings.display;
 
-    // Confirm detaults are set
+    // Confirm detault cuts are set
     settings.cuts.defaults = settings.cuts.defaults || defaults.cuts.defaults;
     settings.cuts.defaults.relative_uln =
         settings.cuts.defaults.relative_uln || defaults.cuts.defaults.relative_uln;

--- a/src/configuration/syncSettings.js
+++ b/src/configuration/syncSettings.js
@@ -112,10 +112,13 @@ export default function syncSettings(settings) {
             typeof settings.baseline.values == 'string' ? [settings.baseline.values] : [];
     }
 
-    //check for 'all' in x_, y_ and point_size_options
+    //check for 'all' in x_, y_ and point_size_options, but keep track if all options are used for later
     const allMeasures = Object.keys(settings.measure_values);
+    settings.x_options_all = settings.x_options == 'all';
     if (settings.x_options == 'all') settings.x_options = allMeasures;
+    settings.y_options_all = settings.y_options == 'all';
     if (settings.y_options == 'all') settings.y_options = allMeasures;
+    settings.point_size_options_all = settings.point_size_options == 'all';
     if (settings.point_size_options == 'all') settings.point_size_options = allMeasures;
 
     //parse x_ and y_options to array if needed

--- a/src/configuration/syncSettings.js
+++ b/src/configuration/syncSettings.js
@@ -1,5 +1,8 @@
+import getDefaults from './settings';
+
 //Replicate settings in multiple places in the settings object
 export default function syncSettings(settings) {
+    const defaults = getDefaults();
     settings.marks[0].per[0] = settings.id_col;
 
     //set grouping config
@@ -109,6 +112,12 @@ export default function syncSettings(settings) {
             typeof settings.baseline.values == 'string' ? [settings.baseline.values] : [];
     }
 
+    //check for 'all' in x_, y_ and point_size_options
+    const allMeasures = Object.keys(settings.measure_values);
+    if (settings.x_options == 'all') settings.x_options = allMeasures;
+    if (settings.y_options == 'all') settings.y_options = allMeasures;
+    if (settings.point_size_options == 'all') settings.point_size_options = allMeasures;
+
     //parse x_ and y_options to array if needed
     if (!(settings.x_options instanceof Array)) {
         settings.x_options = typeof settings.x_options == 'string' ? [settings.x_options] : [];
@@ -118,14 +127,29 @@ export default function syncSettings(settings) {
         settings.y_options = typeof settings.y_options == 'string' ? [settings.y_options] : [];
     }
 
-    // track initial Cutpoint (lets us detect when cutpoint should change)
+    //Attach measure columns to axis settings.
+    settings.x.column = settings.x_options[0];
+    settings.y.column = settings.y_options[0];
+
+    // track initial Cutpoint  (lets us detect when cutpoint should change)
     settings.cuts.x = settings.x.column;
     settings.cuts.y = settings.y.column;
     settings.cuts.display = settings.display;
 
-    //Attach measure columns to axis settings.
-    settings.x.column = settings.x_options[0];
-    settings.y.column = settings.y_options[0];
+    // Confirm detaults are set
+    settings.cuts.defaults = settings.cuts.defaults || defaults.cuts.defaults;
+    settings.cuts.defaults.relative_uln =
+        settings.cuts.defaults.relative_uln || defaults.cuts.defaults.relative_uln;
+    settings.cuts.defaults.relative_baseline =
+        settings.cuts.defaults.relative_baseline || defaults.cuts.defaults.relative_baseline;
+
+    // keep default cuts if user hasn't provided an alternative
+    const cutMeasures = Object.keys(settings.cuts);
+    Object.keys(defaults.cuts).forEach(function(m) {
+        if (cutMeasures.indexOf(m) == -1) {
+            settings.cuts[m] = defaults.cuts[m];
+        }
+    });
 
     return settings;
 }

--- a/test-page/example0/index.html
+++ b/test-page/example0/index.html
@@ -16,7 +16,7 @@
     <body>
       <div id = 'title'>Hepatic Safety Explorer</div>
       <div id = 'subtitle'>Example 0 - Simulated Data</div>
-      <div id = 'info'>This is a demo page for the interactive Hepatic Explorer created by the ASA-DIA Interactive Safety Graphics working group. Code, details and documentation are available on <a href="https://github.com/SafetyGraphics/hep-explorer">github</a>.</div>
+      <div id = 'info'>This is a demo page for the interactive Hepatic Explorer created by the ASA-DIA Interactive Safety Graphics working group. Code, details and documentation are available on <a href='https://github.com/SafetyGraphics/hep-explorer'>github</a>.</div>
       <div id = 'container'></div>
     </body>
 

--- a/test-page/example0/index.js
+++ b/test-page/example0/index.js
@@ -10,12 +10,5 @@ d3.csv(
             } // settings
         );
         instance.init(data);
-        console.log(instance)
-
-        //quick test of participantSelected event
-        instance.chart.wrap.on("participantsSelected",function(){
-          console.log("Participant Selected Event:")
-          console.log(d3.event.data)
-        })
     }
 );

--- a/test-page/example4/index.html
+++ b/test-page/example4/index.html
@@ -1,0 +1,23 @@
+<html>
+    <head>
+        <title>Hepatic Safety Explorer - Example 2</title>
+
+        <meta http-equiv = 'Content-Type' content = 'text/html; charset = utf-8'>
+
+        <script type = 'text/javascript' src = 'https://d3js.org/d3.v3.min.js'></script>
+        <script type = 'text/javascript' src = 'https://cdn.jsdelivr.net/gh/RhoInc/Webcharts@1/build/webcharts.min.js'></script>
+        <script type = 'text/javascript' src = '../../hepexplorer.js'></script>
+        <link type = 'text/css' rel = 'stylesheet' href = 'https://cdn.jsdelivr.net/gh/RhoInc/Webcharts@1/css/webcharts.min.css'>
+        <link type = 'text/css' rel = 'stylesheet' href = '../index.css'>
+
+    </head>
+
+    <body>
+      <div id = 'title'>Hepatic Safety Explorer</div>
+      <div id = 'subtitle'>Example 4 - Example with custom measures</div>
+      <div id= 'info'>This is a demo page for the interactive Hepatic Explorer created by the ASA-DIA Interactive Safety Graphics working group. Code, details and documentation are available on <a href="https://github.com/SafetyGraphics/hep-explorer">github</a>.</div>
+      <div id = 'container'></div>
+    </body>
+
+    <script type = 'text/javascript' src = './index.js'></script>
+</html>

--- a/test-page/example4/index.js
+++ b/test-page/example4/index.js
@@ -31,6 +31,7 @@ const settings = {
         'GGT':"GGT",
         "LDH":"LDH"
     },
+    add_measures:true,
     /*
     **Code below is required when measure_values is customized prior to v1.1.1**
     cuts:{
@@ -60,8 +61,9 @@ const settings = {
       }
     },
     */
-  //  x_options:['ALT', 'AST', 'ALP','GGT',"LDH"],
-    y_options:['TB'],
+    //x_options:['ALT', 'AST', 'ALP','GGT',"LDH"],
+//    x_options:"all",
+  //  y_options:"all",
     baseline:{
         value_col:"STUDYDAY",
         values:[1]

--- a/test-page/example4/index.js
+++ b/test-page/example4/index.js
@@ -60,8 +60,8 @@ const settings = {
       }
     },
     */
-    x_options:['ALT', 'AST', 'ALP','GGT',"LDH"],
-    y_options:['TB', 'GGT', "LDH"],
+  //  x_options:['ALT', 'AST', 'ALP','GGT',"LDH"],
+    y_options:['TB'],
     baseline:{
         value_col:"STUDYDAY",
         values:[1]

--- a/test-page/example4/index.js
+++ b/test-page/example4/index.js
@@ -1,0 +1,81 @@
+const settings = {
+    max_width: 600,
+    value_col: 'LBORRES',
+    measure_col: 'TESTNAM',
+    visit_col:"VISIT",
+    //  visitn_col: 'VISITNUM',
+    studyday_col: 'STUDYDAY',
+    normal_col_low: 'LBORRESLO',
+    normal_col_high: 'LBORRESHI',
+    id_col: 'SUBJID',
+    group_cols: ['TRTA','SEX'],
+    filters: [
+        {
+            value_col: 'TRTA',
+            label: 'Treatment'
+        },
+        {
+            value_col: 'SEX',
+            label: 'Sex'
+        },
+        {
+            value_col: 'SUBJID',
+            label: 'ID'
+        }
+    ],
+    measure_values:{
+        'ALT':'ALT (SGPT)',
+        'AST':'AST (SGOT)',
+        'TB':'Total Bilirubin',
+        'ALP':"Alkaline Phosphatase",
+        'GGT':"GGT",
+        "LDH":"LDH"
+    },
+    /*
+    **Code below is required when measure_values is customized prior to v1.1.1**
+    cuts:{
+      ALT: {
+        relative_baseline: 3.8,
+        relative_uln: 3
+      },
+      AST: {
+        relative_baseline: 3.8,
+        relative_uln: 3
+      },
+      TB: {
+        relative_baseline: 4.8,
+        relative_uln: 2
+      },
+      ALP: {
+        relative_baseline: 3.8,
+        relative_uln: 1
+      },
+      GGT: {
+        relative_baseline: 3.8,
+        relative_uln: 3
+            },
+      LDH: {
+        relative_baseline: 3.8,
+        relative_uln: 3
+      }
+    },
+    */
+    x_options:['ALT', 'AST', 'ALP','GGT',"LDH"],
+    y_options:['TB', 'GGT', "LDH"],
+    baseline:{
+        value_col:"STUDYDAY",
+        values:[1]
+    },
+    analysisFlag:{
+        value_col:"EPOCH",
+        values:["Analysis"]
+    }
+};
+const chart = hepexplorer('#container', settings);
+d3.csv('../example2/allQuads.csv', function(data) {
+    data.forEach(function(d){
+        d.EPOCH = +d.STUDYDAY > 1 ? "Analysis" : "Baseline";
+        d.AgeGroup = +d.AGE < 60 ?  "<60":"60+";
+    })
+    chart.init(data);
+});

--- a/test-page/example4/index.js
+++ b/test-page/example4/index.js
@@ -61,9 +61,6 @@ const settings = {
       }
     },
     */
-    //x_options:['ALT', 'AST', 'ALP','GGT',"LDH"],
-//    x_options:"all",
-  //  y_options:"all",
     baseline:{
         value_col:"STUDYDAY",
         values:[1]


### PR DESCRIPTION
# Release Summary

This release refactors (and greatly simplifies) the configuration for the axis and point size controls.

# Test Notes

- [x] **add_measures** - Confirm that the `add_measures` setting adds additional options under the x-Axis and point size controls. settings = `{add_measures:true}`
- [x] **_options settings** - Confirm that the new "all" option works as expected for the axes and point-size controls. By default, all options should be shown for x and point size, and the y-axis control  should be hidden since TB is the only option. Check that changing settings to `{x_options:["ALT","ALP"],y_options="all", point_size_options:["TB","AST"]}` works as expected both with and without `add_measures:true`.
- [x] **_default settings** - Confirm that changing the `_default` settings updates the default values for the given controls on initial load, and that the controls still work as expected. settings = `{x_default:"ALP",y_options="all", y_default:"ALT", point_size_default:"rRatio"}`
- [x] **Long measure names used** - Confirm that long measure names now appear in the x, y and point size controls by default (e.g. "Aminotransferase, alanine (ALT)" instead of "ALT". Confirm that this works with `add_measures:true` as well as the default view. 
- [x] **ULN Cuts** - Check that updating the cuts object works as expected. With the settings below, TB should have its cut point set to 2, ALP should be 4, AST should be 5 and all other measures should be 6. 
```
{
    "add_measures": true,
    "cuts": {
        "ALP": {
            "relative_baseline": 4.8,
            "relative_uln": 4
        },
        "AST": {
            "relative_baseline": 5.8,
            "relative_uln": 5
        },
        "defaults": {
            "relative_baseline": 6.8,
            "relative_uln": 6
        }
    },
   "baseline": {
        "value_col": "DY",
        "values": [
            1
        ]
    }
}
```
- [x] **ULN Cuts** - Using the same settings as above, change Display Settings control to mDish and then, TB should have its cut point set to 4.8, ALP should be 4.8, AST should be 5.8 and all other measures should be 6.8. 

- [x] **Manually add a custom measure** - Confirm that a single new measure is added to the x axis and point size controls with the settings below. Adding `add_measures:true` to the settings should still add all measures. settings = `{measure_values:{ige:"IgE"}}`
